### PR TITLE
Remove GPL license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@
 	requires-python = ">=3.10"
 	classifiers = [
 		"Intended Audience :: Information Technology",
-		"License :: OSI Approved :: GNU General Public License (GPL)",
 		"Operating System :: POSIX :: Linux",
 		"Programming Language :: Python :: 3",
 		"Typing :: Typed",


### PR DESCRIPTION
```
/usr/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License (GPL)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```